### PR TITLE
Included <ostream> as ScientificQuantities.hpp depends on it. 

### DIFF
--- a/ScientificQuantities.hpp
+++ b/ScientificQuantities.hpp
@@ -13,6 +13,7 @@
 #ifndef SCIENTIFICQUANTITIES_HPP_
 #define SCIENTIFICQUANTITIES_HPP_
 
+#include <ostream>
 #include <cmath>
 #include <assert.h>
 


### PR DESCRIPTION
The header `ScientificQuantities.hpp` now includes `<ostream>` as the code 
depends on `std::ostream` to be available. Including this header ensures that 
users of `ScientificQuantities.hpp` do not have to explicitly include `<ostream>` 
or `<iostream>` before it. In other words, this makes `ScientificQuantities.hpp` 
self-sufficient.
